### PR TITLE
Add solution and include two extra test

### DIFF
--- a/lib/cash_register.py
+++ b/lib/cash_register.py
@@ -1,4 +1,35 @@
 #!/usr/bin/env python3
 
+
 class CashRegister:
-  pass
+    def __init__(self, discount=0):
+        self.discount = discount
+        self.total = 0
+        self.items = []
+        self.previous_transactions = []
+
+    def add_item(self, item, price, quantity=1):
+        self.total += price * quantity
+        for _ in range(quantity):
+            self.items.append(item)
+        self.previous_transactions.append(
+            {"item": item, "quantity": quantity, "price": price}
+        )
+
+    def apply_discount(self):
+        if self.discount:
+            self.total = int(self.total * ((100 - self.discount) / 100))
+            print(f"After the discount, the total comes to ${self.total}.")
+        else:
+            print("There is no discount to apply.")
+
+    def void_last_transaction(self):
+        if not self.previous_transactions:
+            return "There are no transactions to void."
+        self.total -= (
+            self.previous_transactions[-1]["price"]
+            * self.previous_transactions[-1]["quantity"]
+        )
+        for _ in range(self.previous_transactions[-1]["quantity"]):
+            self.items.pop()
+        self.previous_transactions.pop()

--- a/lib/testing/cash_register_test.py
+++ b/lib/testing/cash_register_test.py
@@ -12,8 +12,8 @@ class TestCashRegister:
     cash_register_with_discount = CashRegister(20)
 
     def reset_register_totals(self):
-      self.cash_register.total = 0
-      self.cash_register_with_discount.total = 0
+        self.cash_register.total = 0
+        self.cash_register_with_discount.total = 0
 
     def test_discount_attribute(self):
         '''takes one optional argument, a discount, on initialization.'''
@@ -24,6 +24,16 @@ class TestCashRegister:
         '''sets an instance variable total on initialization to zero.'''
         assert(self.cash_register.total == 0)
         assert(self.cash_register_with_discount.total == 0)
+
+    def test_items_attribute(self):
+        '''sets an instance variable items to empty list on initialization.'''
+        assert(self.cash_register.items == [])
+        assert(self.cash_register_with_discount.items == [])
+    
+    def test_previous_transactions_attribute(self):
+        '''sets an instance variable previous_transactions to an empty list on initialization.'''
+        assert(self.cash_register.previous_transactions == [])
+        assert(self.cash_register_with_discount.previous_transactions == [])
 
     def test_add_item(self):
         '''accepts a title and a price and increases the total.'''
@@ -98,17 +108,16 @@ class TestCashRegister:
         assert(new_register.items == ["eggs", "eggs", "tomato", "tomato", "tomato"])
 
     def test_void_last_transaction(self):
-      '''subtracts the last item from the total'''
-      self.cash_register.add_item("apple", 0.99)
-      self.cash_register.add_item("tomato", 1.76)
-      self.cash_register.void_last_transaction()
-      assert(self.cash_register.total == 0.99)
-      self.reset_register_totals()
+        '''subtracts the last item from the total'''
+        self.cash_register.add_item("apple", 0.99)
+        self.cash_register.add_item("tomato", 1.76)
+        self.cash_register.void_last_transaction()
+        assert(self.cash_register.total == 0.99)
+        self.reset_register_totals()
 
     def test_void_last_transaction_with_multiples(self):
-      '''returns the total to 0.0 if all items have been removed'''
-      self.cash_register.add_item("tomato", 1.76, 2)
-      self.cash_register.void_last_transaction() 
-      assert(self.cash_register.total == 0.0)
-      self.reset_register_totals()
-      
+        '''returns the total to 0.0 if all items have been removed'''
+        self.cash_register.add_item("tomato", 1.76, 2)
+        self.cash_register.void_last_transaction() 
+        assert(self.cash_register.total == 0.0)
+        self.reset_register_totals()


### PR DESCRIPTION
This is an alternative solution to the one proposed in PR #1. Similarly to that one, there is a new test called test_items_attribute, but the main different is how the "previous transaction" logic is handled. Rather than setting three attributes I suggest using one dictionary. I also believe that we should keep track of all previous transactions inside a list if we need to be able to void multiple transactions over time. I added a simple test called test_previous_transactions_attribute to enforce its setup within init() following the same pattern as #items.